### PR TITLE
Add support for UUID in encodePathParam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+*.iml
+*/target

--- a/bmc-common/src/main/java/com/oracle/bmc/util/internal/HttpUtils.java
+++ b/bmc-common/src/main/java/com/oracle/bmc/util/internal/HttpUtils.java
@@ -6,6 +6,7 @@ package com.oracle.bmc.util.internal;
 import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
 
 import java.util.Date;
+import java.util.UUID;
 
 import javax.annotation.Nonnull;
 
@@ -57,6 +58,16 @@ public class HttpUtils {
      * @return The encoded path segment.
      */
     public static String encodePathSegment(@Nonnull Character pathSegment) {
+        return urlPathSegmentEscaper().escape(pathSegment.toString());
+    }
+
+    /**
+     * Encodes a path segment.
+     *
+     * @param pathSegment The path segment to encode.
+     * @return The encoded path segment.
+     */
+    public static String encodePathSegment(@Nonnull UUID pathSegment) {
         return urlPathSegmentEscaper().escape(pathSegment.toString());
     }
 

--- a/bmc-common/src/test/java/com/oracle/bmc/util/internal/HttpUtilsTest.java
+++ b/bmc-common/src/test/java/com/oracle/bmc/util/internal/HttpUtilsTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
 
+import java.util.UUID;
+
 public class HttpUtilsTest {
 
     @Test
@@ -29,6 +31,12 @@ public class HttpUtilsTest {
         assertEquals("50.5", HttpUtils.encodePathSegment(50.5D));
         assertEquals("100.5", HttpUtils.encodePathSegment(100.5F));
         assertEquals("20", HttpUtils.encodePathSegment((short) 20));
+    }
+
+    @Test
+    public void encodePathSegment_uuid() {
+        UUID uuid = UUID.randomUUID();
+        assertEquals(uuid.toString(), HttpUtils.encodePathSegment(uuid));
     }
 
     @Test


### PR DESCRIPTION
Swagger has support for strings with format `uuid`.
This adds support for overloading the encodePathParam to allow UUIDs as method argument.

Also added some sensible defaults to the gitignore for IntelliJ

Signed-off-by: Farid Zakaria <farid.m.zakaria@gmail.com>