### PR TITLE
source input stream is duplicable should be judged by its own capability

### DIFF
--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/transfer/UploadManager.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/transfer/UploadManager.java
@@ -113,7 +113,7 @@ public class UploadManager {
 
         final ExecutorService executorServiceToUse;
         final boolean shutdownExecutor;
-        if (uploadConfiguration.isAllowParallelUploads() && chunkCreator.enableParallelReads()) {
+        if (uploadConfiguration.isAllowParallelUploads() && chunkCreator.supportsParallelReads()) {
             if (uploadDetails.parallelUploadExecutorService != null) {
                 executorServiceToUse = uploadDetails.parallelUploadExecutorService;
                 shutdownExecutor = false;

--- a/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/transfer/internal/StreamChunkCreator.java
+++ b/bmc-objectstorage/src/main/java/com/oracle/bmc/objectstorage/transfer/internal/StreamChunkCreator.java
@@ -3,12 +3,11 @@
  */
 package com.oracle.bmc.objectstorage.transfer.internal;
 
+import com.oracle.bmc.io.DuplicatableInputStream;
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.IOException;
 import java.io.InputStream;
-
-import com.oracle.bmc.io.DuplicatableInputStream;
-
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class StreamChunkCreator {
@@ -38,6 +37,10 @@ public class StreamChunkCreator {
             canDuplicate = true;
         }
         return canDuplicate;
+    }
+
+    private boolean isSrcStreamDuplicable() {
+        return source instanceof DuplicatableInputStream;
     }
 
     /**
@@ -71,7 +74,7 @@ public class StreamChunkCreator {
 
         SubRangeInputStream rangeInputStream = null;
 
-        if (canDuplicate) {
+        if (isSrcStreamDuplicable()) {
             rangeInputStream =
                     new DuplicatedSubRangeInputStream(
                             (DuplicatableInputStream) source, startPosition, endPosition);

--- a/bmc-objectstorage/src/test/java/com/oracle/bmc/objectstorage/transfer/internal/StreamChunkCreatorTest.java
+++ b/bmc-objectstorage/src/test/java/com/oracle/bmc/objectstorage/transfer/internal/StreamChunkCreatorTest.java
@@ -79,7 +79,7 @@ public class StreamChunkCreatorTest {
     public void parallelChunks_readInOrder() throws Exception {
         StreamChunkCreator creator =
                 new StreamChunkCreator(stream, COMPLETE_STRING.length(), CHUNK_SIZE);
-        assertTrue(creator.enableParallelReads());
+        assertTrue(creator.supportsParallelReads());
 
         int chunkCount = 0;
         while (creator.hasMore()) {
@@ -103,7 +103,7 @@ public class StreamChunkCreatorTest {
     public void parallelChunks_readOutOfOrder() throws Exception {
         StreamChunkCreator creator =
                 new StreamChunkCreator(stream, COMPLETE_STRING.length(), CHUNK_SIZE);
-        assertTrue(creator.enableParallelReads());
+        assertTrue(creator.supportsParallelReads());
 
         ArrayList<SubRangeInputStream> chunks = new ArrayList<>();
         while (creator.hasMore()) {


### PR DESCRIPTION
It's lated to the issue I opened at https://github.com/oracle/bmcs-java-sdk/issues/11. 
Not sure it's the best solution, but it does solve my current problem.